### PR TITLE
scripts: refactoring of scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,13 @@ INTERACTIVE_SETTING:=
 TTY_SETTING:=
 endif
 
+SCRIPTS_DIR=/home/zondax/shared/scripts
+
 QEMU_SERIAL1=54320
 QEMU_SERIAL2=54321
 GDB_SERVER=1234
 
-SCRIPTS_DIR=/home/zondax/shared/scripts
-
+# $(2) is MACHINE
 define run_docker
 	docker run $(TTY_SETTING) $(INTERACTIVE_SETTING) --rm \
 	--privileged \
@@ -29,6 +30,7 @@ define run_docker
 	"$(1)"
 endef
 
+# $(2) is MACHINE
 define run_docker_ext
 	docker run $(TTY_SETTING) $(INTERACTIVE_SETTING) --rm \
 	--privileged \
@@ -43,47 +45,70 @@ define run_docker_ext
 	"$(1)"
 endef
 
+define run_docker_recipe
+	$(eval MACHINE := $(word 1, $(2)))
+	$(eval RECIPE := $(word 2, $(2)))
+	docker run $(TTY_SETTING) $(INTERACTIVE_SETTING) --rm \
+	--privileged \
+	-u $(shell id -u) \
+	-v $(shell pwd)/shared:/home/zondax/shared \
+	-v $(RUSTEE_APP_LOCAL):/home/zondax/hello-rustee.git \
+	-p 8000:8000	\
+	-e DISPLAY=$(shell echo ${DISPLAY}) \
+	-v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+	-e ZONDAX_CONF=$(MACHINE) \
+	-e ZONDAX_RECIPE=$(RECIPE) \
+	$(DOCKER_IMAGE) \
+	"$(1)"
+endef
+
+.PHONY: pull_docker
 pull_docker:
 	docker pull $(DOCKER_IMAGE)
 
+.PHONY: pull_manifest
+pull_manifest: pull_docker
+	$(call run_docker,$(SCRIPTS_DIR)/zxfetch.sh,null)
+
+.PHONY: login
 login: pull_docker
 	$(call run_docker,zsh)
 
-shell_bytesatwork: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,bytesatwork)
-
-shell_dk2: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,dk2)
-
-shell_imx8mq: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,imx8mq)
-
-shell_qemu: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,qemu)
-
-shell_qemu8: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,qemu8)
-
+.PHONY: toaster
 toaster: pull_docker
 	$(call run_docker_ext,$(SCRIPTS_DIR)/zxtoaster.sh,dk2)
 
-build_image_bytesatwork: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,bytesatwork)
+.PHONY: shell
+shell: pull_docker
+	$(call run_docker,$(SCRIPTS_DIR)/zxshell.sh,$(filter-out $@,$(MAKECMDGOALS)))
 
-build_image_dk2: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,dk2)
+# Building images
+.PHONY: build
+build: pull_docker
+	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,$(filter-out $@,$(MAKECMDGOALS)))
 
-build_image_imx8mq: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,imx8mq)
+.PHONY: run
+run : pull_docker
+	$(call run_docker,$(SCRIPTS_DIR)/zxrun.sh,$(filter-out $@,$(MAKECMDGOALS)))
 
-build_image_qemu: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,qemu)
+# Creating workspace so you can work locally on recipe source code
+# Example:
+# $ make workspace <recipe-name>
+.PHONY: workspace
+workspace: pull_docker
+	$(call run_docker_recipe,$(SCRIPTS_DIR)/zxworkspace.sh,$(filter-out $@,$(MAKECMDGOALS)))
 
-build_image_qemu8: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxbuild.sh,qemu8)
+.PHONY: help
+help:
+	@echo "Usage:"
+	@echo "   make pull_docker                  Fetch Zondax docker image"
+	@echo "   make pull_manifest                Fetch Zondax repo manifest"
+	@echo "   make login                        Simply login into docker container"
+	@echo "   make build <target>               Build image for <target>"
+	@echo "   make shell <target>               Get shell for <target>"
+	@echo "   make workspace <target> <recipe>  Create a workspace for recipe"
+	@echo "   make run <qemu|qemu8>             Run QEMU ARMv7/QEMU ARMv8 emulation"
 
-run_qemu: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxrun.sh,qemu)
-
-run_qemu8: pull_docker
-	$(call run_docker,$(SCRIPTS_DIR)/zxrun.sh,qemu8)
+# Drop other targets
+%:
+	@:

--- a/shared/scripts/zxbuild.sh
+++ b/shared/scripts/zxbuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source $DIR/zxenv.sh
+source $DIR/zxconfigure
 
 # Build
 bitbake ${IMAGE_NAME}
@@ -13,7 +13,7 @@ if [[ $? -ne 0 ]] ; then
 fi
 
 IMAGE_DIR="${BUILDDIR}/${IMAGE_DIR}"
-IMAGEOUTPUT_DIR=$HOME/shared/images/$ZONDAX_CONF
+IMAGEOUTPUT_DIR=${HOME}/shared/images/${ZONDAX_CONF}
 
 mkdir -p $IMAGEOUTPUT_DIR
 

--- a/shared/scripts/zxconfigure
+++ b/shared/scripts/zxconfigure
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# This script prepares the environment for Yocto builds
+# This script prepares MACHINE-specific environment for Yocto builds
 
-PATH=$PATH:$HOME/shared/scripts
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxenv
 
-# Zondax manifest
 if [ "$ZONDAX_CONF" == "dk2" ]; then
 	echo "Building for STM32 DK2"
 
@@ -32,7 +32,12 @@ elif [ "$ZONDAX_CONF" == "qemu" ]; then
 	MACHINE=qemu-optee32
 	IMAGE_DIR=tmp/deploy/images/qemu-optee32
 	BSP_LAYERS=(meta-zondax-qemu)
+else
+	echo "Unsupported platform $ZONDAX_CONF, exiting..."
+
+	exit 1
 fi
+
 function bsp_layers_current_add () {
 	for i in "${BSP_LAYERS[@]}"; do bitbake-layers add-layer ${ROOT_DIR}/$i; done
 }
@@ -45,37 +50,8 @@ function custom_layers_clean_all () {
 	for i in "${CUSTOM_LAYERS_FULL[@]}"; do bitbake-layers remove-layer ${ROOT_DIR}/$i; done
 }
 
-MANIFEST_BRANCH=thud
-MANIFEST_URL=https://github.com/Zondax/zondbox-manifest
-MANIFEST_FILE=default.xml
-ENV_SOURCE="poky/oe-init-build-env build"
-IMAGE_NAME=core-image-minimal
-export DISTRO=zondbox-distro
 export MACHINE=$MACHINE
-
-ROOT_DIR=$HOME/shared/${DISTRO}
 declare EULA_${MACHINE}=1
-
-BUILD_DIR=$ROOT_DIR/build
-echo
-echo "-----------------------------------------------------------------------"
-echo "Fetching \"${DISTRO}\" distribution."
-echo "From ${MANIFEST_URL}/${MANIFEST_FILE}, branch/tag: ${MANIFEST_BRANCH}"
-echo "The recommended development image is: ${IMAGE_NAME}"
-echo "-----------------------------------------------------------------------"
-echo
-
-# Checkout and clone manifest
-mkdir -p ${ROOT_DIR}
-cd ${ROOT_DIR}
-repo init --depth=1 --no-clone-bundle -u ${MANIFEST_URL} -b ${MANIFEST_BRANCH} -m ${MANIFEST_FILE}
-repo sync -c -j$(nproc --all) --fetch-submodules --current-branch --no-clone-bundle
-
-echo "-----------------------------------------------------------------------"
-echo Setting up environment...
-echo "-----------------------------------------------------------------------"
-
-source ${ENV_SOURCE}
 
 echo "-----------------------------------------------------------------------"
 echo Adding all needed distro layers...
@@ -102,14 +78,3 @@ echo Packages that going to be built:
 echo "-----------------------------------------------------------------------"
 
 bitbake -g core-image-minimal && cat pn-buildlist | grep -ve "native" | sort | uniq
-echo
-echo "-----------------------------------------------------------------------"
-echo To build run zxbuild.sh
-echo Bitbake cheatsheet
-echo "   bitbake <image>                    e.g. bitbake ${IMAGE_NAME}"
-echo "   bitbake <recipe>                   e.g. bitbake optee-hellorustee"
-echo "   bitbake <package> -c listtasks     e.g. bitbake optee-hellorustee -c listtasks"
-echo "   bitbake <package> -c <taskname>    e.g. bitbake optee-hellorustee -c devshell"
-echo "   bitbake-layers show-layers"
-echo "   bitbake-layers show-recipes"
-echo "-----------------------------------------------------------------------"

--- a/shared/scripts/zxenv
+++ b/shared/scripts/zxenv
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# This script prepares default Poky environment for Yocto builds
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxsettings
+
+echo "-----------------------------------------------------------------------"
+echo Setting up environment...
+echo "-----------------------------------------------------------------------"
+
+cd ${ROOT_DIR}
+source ${ENV_SOURCE}

--- a/shared/scripts/zxfetch.sh
+++ b/shared/scripts/zxfetch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This script fetches/updates Zondax manifest
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxsettings
+
+echo
+echo "-----------------------------------------------------------------------"
+echo "Fetching \"${DISTRO}\" distribution."
+echo "From ${MANIFEST_URL}/${MANIFEST_FILE}, branch/tag: ${MANIFEST_BRANCH}"
+echo "The recommended development image is: ${IMAGE_NAME}"
+echo "-----------------------------------------------------------------------"
+echo
+
+# Checkout and clone manifest
+mkdir -p ${ROOT_DIR}
+cd ${ROOT_DIR}
+
+repo init --depth=1 --no-clone-bundle -u ${MANIFEST_URL} \
+	  -b ${MANIFEST_BRANCH} -m ${MANIFEST_FILE}
+repo sync -c -j$(nproc --all) --fetch-submodules \
+	  --current-branch --no-clone-bundle

--- a/shared/scripts/zxrun.sh
+++ b/shared/scripts/zxrun.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxsettings
 
-DISTRO=zondbox-distro
-ROOT_DIR=$HOME/shared/${DISTRO}
-BUILDDIR=$ROOT_DIR/build
-IMAGEOUTPUT_DIR=$HOME/shared/images/$ZONDAX_CONF
+IMAGEOUTPUT_DIR=$DIR/../images/${ZONDAX_CONF}
 
 echo "Please use telnet to receive console output: "
 echo "    NW output > telnet 127.0.0.1 54320"
@@ -14,7 +12,7 @@ echo "    SW output > telnet 127.0.0.1 54321"
 if [ "$ZONDAX_CONF" == "qemu8" ]; then
 	set -e
 
-	ROOT_NATIVE=$BUILDDIR/tmp/work/qemu_optee64-poky-linux/core-image-minimal/1.0-r0/recipe-sysroot-native
+	ROOT_NATIVE=$BUILD_DIR/tmp/work/qemu_optee64-poky-linux/core-image-minimal/1.0-r0/recipe-sysroot-native
 
 	cd $IMAGEOUTPUT_DIR && $ROOT_NATIVE/usr/bin/qemu-system-aarch64 \
 		-s -S \
@@ -34,7 +32,7 @@ if [ "$ZONDAX_CONF" == "qemu8" ]; then
 elif [ "$ZONDAX_CONF" == "qemu" ]; then
 	set -e
 
-	ROOT_NATIVE=$BUILDDIR/tmp/work/qemu_optee32-poky-linux-gnueabi/core-image-minimal/1.0-r0/recipe-sysroot-native
+	ROOT_NATIVE=$BUILD_DIR/tmp/work/qemu_optee32-poky-linux-gnueabi/core-image-minimal/1.0-r0/recipe-sysroot-native
 
 	cd $IMAGEOUTPUT_DIR && $ROOT_NATIVE/usr/bin/qemu-system-arm \
 		-s -S \

--- a/shared/scripts/zxsettings
+++ b/shared/scripts/zxsettings
@@ -1,0 +1,15 @@
+# contains common settings
+
+# Yocto-specific variables
+export ENV_SOURCE="poky/oe-init-build-env build"
+export IMAGE_NAME=core-image-minimal
+export DISTRO=zondbox-distro
+
+# Paths
+export ROOT_DIR=${HOME}/shared/${DISTRO}
+export BUILD_DIR=${ROOT_DIR}/build
+
+# Zondax repo manifest
+export MANIFEST_BRANCH=thud
+export MANIFEST_URL=https://github.com/Zondax/zondbox-manifest
+export MANIFEST_FILE=default.xml

--- a/shared/scripts/zxshell.sh
+++ b/shared/scripts/zxshell.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
-. $HOME/shared/scripts/zxenv.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxconfigure
+
+echo
+echo "-----------------------------------------------------------------------"
+echo To build run zxbuild.sh
+echo Bitbake cheatsheet
+echo "   bitbake <image>                    e.g. bitbake ${IMAGE_NAME}"
+echo "   bitbake <recipe>                   e.g. bitbake optee-hellorustee"
+echo "   bitbake <package> -c listtasks     e.g. bitbake optee-hellorustee -c listtasks"
+echo "   bitbake <package> -c <taskname>    e.g. bitbake optee-hellorustee -c devshell"
+echo "   bitbake-layers show-layers"
+echo "   bitbake-layers show-recipes"
+echo "-----------------------------------------------------------------------"
 
 zsh

--- a/shared/scripts/zxtoaster.sh
+++ b/shared/scripts/zxtoaster.sh
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-cd $DIR
-BRANCH=zeus
-
-if cd poky; then 
-    git pull; 
-else 
-    git clone --depth=1 git://git.yoctoproject.org/poky  -b $BRANCH
-    cd poky
-fi
-
-source oe-init-build-env
+source $DIR/zxconfigure
 
 # # Install toaster dependencies
-pip3 install -r $HOME/shared/poky/bitbake/toaster-requirements.txt
+pip3 install -r $ROOT_DIR/poky/bitbake/toaster-requirements.txt
 source toaster start webport=0.0.0.0:8000
 zsh

--- a/shared/scripts/zxworkspace.sh
+++ b/shared/scripts/zxworkspace.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/zxconfigure
+
+
+devtool modify ${ZONDAX_RECIPE}
+if [[ $? -ne 0 ]] ; then
+	echo
+	echo "Error creating workspace for ${ZONDAX_RECIPE}"
+	echo
+    exit 1
+fi
+
+echo "-----------------------------------------------------------------------"
+echo "Find local sources for ${ZONDAX_RECIPE} recipe here:"
+echo "$BUILD_DIR/workspace/sources"
+echo "-----------------------------------------------------------------------"


### PR DESCRIPTION
Split into more dedicated scripts, there are now:
```
zxsettings - contains common config vars
zxenv - Poky PATH script wrapper
zxfetch.sh - fetch Zondax manifest
zxrun.sh - for QEMU emulator invocation
zxconfigure - configure Yocto setup for particular BSP/MACHINE
zxworkspace.sh - create workspace for a recipe for local development
```

For usage details just run:
```
$ make help
```
`Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>`